### PR TITLE
Adjust icon and canvas size

### DIFF
--- a/App_Resources/documentscanner/Android/src/main/res/drawable/launcher_icon_monochrome.xml
+++ b/App_Resources/documentscanner/Android/src/main/res/drawable/launcher_icon_monochrome.xml
@@ -1,29 +1,30 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="34.512dp"
-    android:height="40.064dp"
-    android:viewportWidth="34.512"
-    android:viewportHeight="40.064">
-  <path
-      android:pathData="M22.963,14.898L22.963,28.589L13.966,28.589a2.567,2.454 90,0 1,-2.454 -2.567L11.512,11.475l8.179,0z"
-      android:strokeLineJoin="round"
-      android:strokeWidth="1.237"
-      android:fillColor="#00000000"
-      android:strokeColor="#000000"
-      android:fillAlpha="0.588235"
-      android:strokeLineCap="round"/>
-  <path
-      android:pathData="m22.575,15.368l-2.985,0l0,-3.123zM20.709,19.662L13.247,19.662a0.39,0.373 90,0 1,0 -0.781l7.462,0a0.39,0.373 90,0 1,0 0.781zM20.709,17.71L13.247,17.71a0.39,0.373 90,0 1,0 -0.781l7.462,0a0.39,0.373 90,0 1,0 0.781zM20.709,21.613L13.247,21.613a0.39,0.373 90,0 1,0 -0.781l7.462,0a0.39,0.373 90,0 1,0 0.781zM20.709,23.565L13.247,23.565a0.39,0.373 90,0 1,0 -0.781l7.462,0a0.39,0.373 90,0 1,0 0.781zM16.978,25.516l-3.731,0a0.39,0.373 90,0 1,0 -0.781l3.731,0a0.39,0.373 90,0 1,0 0.781z"
-      android:strokeLineJoin="round"
-      android:strokeWidth="0"
-      android:fillColor="#000000"
-      android:strokeColor="#000000"
-      android:strokeLineCap="round"/>
-  <path
-      android:pathData="M9.917,21.109l14.678,0l0,0.361l-14.678,0z"
-      android:strokeLineJoin="round"
-      android:strokeWidth="0.82"
-      android:fillColor="#da5669"
-      android:strokeColor="#000000"
-      android:fillType="evenOdd"
-      android:strokeLineCap="round"/>
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="40.059"
+    android:viewportHeight="40.059">
+    <path
+        android:pathData="M25.737,14.898L25.737,28.589L16.74,28.589a2.567,2.454 90,0 1,-2.454 -2.567L14.286,11.475l8.179,0z"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.237"
+        android:fillColor="#00000000"
+        android:strokeColor="#000000"
+        android:fillAlpha="0.588235"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="m25.507,15.368l-3.144,0l0,-3.31zM23.483,19.662L16.021,19.662c-0.497,-0 -0.497,-0.781 0,-0.781l7.462,0c0.497,0 0.497,0.781 0,0.781zM23.483,17.71L16.021,17.71c-0.497,-0.001 -0.497,-0.78 0,-0.781l7.462,0c0.497,0.001 0.497,0.78 0,0.781zM23.483,21.613L16.021,21.613c-0.497,0 -0.497,-0.781 0,-0.781l7.462,0c0.497,0 0.497,0.781 0,0.781zM23.483,23.565L16.021,23.565c-0.497,0 -0.497,-0.781 0,-0.781l7.462,0c0.497,0 0.497,0.781 0,0.781zM19.752,25.516l-3.731,0c-0.497,-0.001 -0.497,-0.78 0,-0.781l3.731,0c0.497,0.001 0.497,0.78 0,0.781z"
+        android:strokeLineJoin="round"
+        android:strokeWidth="0"
+        android:fillColor="#000000"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M12.691,21.109l14.678,0l0,0.361l-14.678,0z"
+        android:strokeLineJoin="round"
+        android:strokeWidth="0.82"
+        android:fillColor="#da5669"
+        android:strokeColor="#000000"
+        android:fillType="evenOdd"
+        android:strokeLineCap="round"/>
 </vector>
+

--- a/documentscanner-icon-monochrome.svg
+++ b/documentscanner-icon-monochrome.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   viewBox="0 0 34.512051 40.063583"
+   viewBox="0 0 40.059347 40.059347"
    version="1.1"
    id="svg6"
    sodipodi:docname="documentscanner-icon-monochrome.svg"
-   width="34.512051"
-   height="40.063583"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   width="108"
+   height="108"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -24,10 +24,10 @@
      inkscape:deskcolor="#d1d1d1"
      showgrid="false"
      inkscape:zoom="27.812866"
-     inkscape:cx="9.1863959"
-     inkscape:cy="20.691862"
-     inkscape:window-width="1920"
-     inkscape:window-height="999"
+     inkscape:cx="43.505045"
+     inkscape:cy="45.590411"
+     inkscape:window-width="3840"
+     inkscape:window-height="2091"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
@@ -39,17 +39,18 @@
      fit-margin-bottom="0" />
   <g
      id="g15261"
-     transform="matrix(0.7325497,0,0,0.76637747,3.3761068,4.3068371)">
+     transform="matrix(0.7325497,0,0,0.76637747,6.149755,4.3068371)">
     <path
        d="M 26.738258,13.819271 V 31.684015 H 14.456247 a 3.3496395,3.3496395 0 0 1 -3.349639,-3.34964 V 9.3530854 h 11.165464 z"
        fill="#edebf2"
        id="path2"
-       style="fill:none;fill-opacity:0.588235;stroke:#000000;stroke-width:1.65093429;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       style="fill:none;fill-opacity:0.588235;stroke:#000000;stroke-width:1.65093;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       d="m 26.207748,14.433276 h -4.074423 v -4.074422 z m -2.546514,5.602332 H 13.475177 a 0.50930312,0.50930312 0 0 1 0,-1.018606 h 10.186057 a 0.50930312,0.50930312 0 0 1 0,1.018606 z m 0,-2.546515 H 13.475177 a 0.5093029,0.5093029 0 0 1 0,-1.018605 h 10.186057 a 0.5093029,0.5093029 0 0 1 0,1.018605 z m 0,5.09303 H 13.475177 a 0.5093035,0.5093035 0 0 1 0,-1.018607 h 10.186057 a 0.5093035,0.5093035 0 0 1 0,1.018607 z m 0,2.546514 H 13.475177 a 0.509303,0.509303 0 0 1 0,-1.018606 h 10.186057 a 0.509303,0.509303 0 0 1 0,1.018606 z m -5.093029,2.546514 h -5.093028 a 0.5093029,0.5093029 0 0 1 0,-1.018605 h 5.093028 a 0.5093029,0.5093029 0 0 1 0,1.018605 z"
+       d="m 26.425056,14.433276 h -4.291731 v -4.318777 z m -2.763822,5.602332 H 13.475177 c -0.678604,-4.66e-4 -0.678604,-1.019072 0,-1.018606 h 10.186057 c 0.678604,4.66e-4 0.678604,1.019072 0,1.018606 z m 0,-2.546515 H 13.475177 c -0.678219,-8.5e-4 -0.678219,-1.017755 0,-1.018605 h 10.186057 c 0.678219,8.5e-4 0.678219,1.017755 0,1.018605 z m 0,5.09303 H 13.475177 c -0.679071,0 -0.679071,-1.018607 0,-1.018607 h 10.186057 c 0.679071,0 0.679071,1.018607 0,1.018607 z m 0,2.546514 H 13.475177 c -0.67907,0 -0.67907,-1.018606 0,-1.018606 h 10.186057 c 0.67907,0 0.67907,1.018606 0,1.018606 z m -5.093029,2.546514 h -5.093028 c -0.678219,-8.5e-4 -0.678219,-1.017755 0,-1.018605 h 5.093028 c 0.678219,8.5e-4 0.678219,1.017755 0,1.018605 z"
        fill="#c6c3d8"
        id="path4"
-       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       sodipodi:nodetypes="ccccccccccccccssssssssssccccc" />
     <rect
        style="fill:#da5669;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.09422;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect174"


### PR DESCRIPTION
Adjusts the size of the monochrome icon drawable to be 108x108 in addition to adjusting the size of the "dog-ear" to prevent the background showing through on specific occasions.

Fixes #59 

Before:
![Screenshot from 2024-01-01 16-15-23](https://github.com/Akylas/com.akylas.documentscanner/assets/80724816/9c0bbb43-64a6-4acb-a444-910062965206)
After:
![Screenshot from 2024-01-01 16-15-32](https://github.com/Akylas/com.akylas.documentscanner/assets/80724816/f53567ff-e16b-4167-a17e-1b3e8ab8236e)
